### PR TITLE
Add new side-by-side fCO2 figure

### DIFF
--- a/story/components/fco2-maps.js
+++ b/story/components/fco2-maps.js
@@ -1,0 +1,180 @@
+import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react'
+import { Minimap, Path, Sphere, Raster } from '@carbonplan/minimaps'
+import { naturalEarth1 } from '@carbonplan/minimaps/projections'
+import { useThemedColormap } from '@carbonplan/colormaps'
+import { Colorbar, Column, Row } from '@carbonplan/components'
+import zarr from 'zarr-js'
+import { Box, Flex, useThemeUI } from 'theme-ui'
+
+import PlayPause from './play-pause'
+import DraggableValue from './draggable-value'
+
+const SOURCE_URL =
+  'https://carbonplan-data-viewer.s3.us-west-2.amazonaws.com/demo/leap-data-stories/annual-sfco2.zarr'
+const VARIABLE = 'sfco2'
+
+const CLIM = [280, 440]
+const FILL_VALUE = 9.969209968386869e36
+const START_YEAR = 1990
+const END_YEAR = 2018
+
+const FCO2Maps = ({ delay = 500 }) => {
+  const { theme } = useThemeUI()
+  const colormap = useThemedColormap('warm')
+  const [playing, setPlaying] = useState(false)
+  const [year, setYear] = useState(START_YEAR)
+  const [chunks, setChunks] = useState(null)
+  const timeout = useRef(null)
+
+  useEffect(() => {
+    try {
+      zarr().load(`${SOURCE_URL}/${VARIABLE}`, (err, arr) => {
+        if (err) {
+          console.error('Error loading array:', err)
+          return
+        }
+        setChunks(arr)
+      })
+    } catch (error) {
+      console.error('Error fetching group:', error)
+    }
+  }, [])
+
+  const data = useMemo(() => {
+    if (chunks) {
+      return {
+        measured: chunks.pick(0, year - START_YEAR, null, null),
+        reconstructed: chunks.pick(1, year - START_YEAR, null, null),
+      }
+    } else {
+      return {}
+    }
+  }, [chunks, year])
+
+  const handlePlay = useCallback(
+    (willPlay) => {
+      if (timeout.current) {
+        clearTimeout(timeout.current)
+        timeout.current = null
+      }
+
+      setPlaying(willPlay)
+      if (willPlay) {
+        const incrementTime = () => {
+          timeout.current = setTimeout(() => {
+            let shouldContinue = true
+            setYear((prev) => {
+              let nextValue = prev + 1
+              if (nextValue > END_YEAR) {
+                nextValue = START_YEAR
+                shouldContinue = false
+                setPlaying(false)
+              }
+              return nextValue
+            })
+            if (shouldContinue) {
+              incrementTime()
+            }
+          }, delay)
+        }
+        incrementTime()
+      }
+    },
+    [delay]
+  )
+
+  return (
+    <PlayPause
+      playing={playing}
+      setPlaying={handlePlay}
+      controls={
+        <DraggableValue
+          value={year}
+          range={[START_YEAR, END_YEAR]}
+          setValue={setYear}
+          sx={{ fontSize: 2 }}
+        />
+      }
+    >
+      <Row columns={[6]} sx={{ mt: 3 }}>
+        <Column start={1} width={[6, 3, 3, 3]}>
+          <Box sx={{ color: 'secondary' }}>Measured</Box>
+
+          <Box sx={{ mx: [-3, -3, -3, -5] }}>
+            <Minimap projection={naturalEarth1} scale={1} translate={[0, 0]}>
+              <Path
+                stroke={theme.colors.primary}
+                source={
+                  'https://cdn.jsdelivr.net/npm/world-atlas@2/land-50m.json'
+                }
+                feature={'land'}
+                opacity={0.3}
+                fill={theme.colors.muted}
+              />
+              <Sphere
+                stroke={theme.colors.primary}
+                fill={theme.colors.background}
+                strokeWidth={1}
+              />
+              {data.measured && (
+                <Raster
+                  source={data.measured}
+                  colormap={colormap}
+                  clim={CLIM}
+                  mode={'lut'}
+                  nullValue={FILL_VALUE}
+                />
+              )}
+            </Minimap>
+          </Box>
+        </Column>
+        <Column start={[1, 4, 4, 4]} width={[6, 3, 3, 3]}>
+          <Box sx={{ color: 'secondary' }}>Reconstructed</Box>
+
+          <Box sx={{ mx: [-3, -3, -3, -5] }}>
+            <Minimap projection={naturalEarth1} scale={1} translate={[0, 0]}>
+              <Path
+                stroke={theme.colors.primary}
+                source={
+                  'https://cdn.jsdelivr.net/npm/world-atlas@2/land-50m.json'
+                }
+                feature={'land'}
+                opacity={0.3}
+                fill={theme.colors.muted}
+              />
+              <Sphere
+                stroke={theme.colors.primary}
+                fill={theme.colors.background}
+                strokeWidth={1}
+              />
+              {data.reconstructed && (
+                <Raster
+                  source={data.reconstructed}
+                  colormap={colormap}
+                  clim={CLIM}
+                  mode={'lut'}
+                  nullValue={FILL_VALUE}
+                />
+              )}
+            </Minimap>
+          </Box>
+        </Column>
+      </Row>
+      <Flex sx={{ justifyContent: 'flex-end', mt: 3 }}>
+        <Colorbar
+          colormap={colormap}
+          clim={CLIM}
+          horizontal
+          label={
+            <Box as='span' sx={{ textTransform: 'none' }}>
+              fCO₂
+            </Box>
+          }
+          units={'μatm'}
+        />
+      </Flex>
+    </PlayPause>
+  )
+}
+
+export default FCO2Maps

--- a/story/components/index.js
+++ b/story/components/index.js
@@ -1,4 +1,5 @@
 export { default as Map } from './map'
+export { default as FCO2Maps } from './fco2-maps'
 export { default as FluxMaps } from './flux-maps'
 export { default as OceanCycleDiagram } from './ocean-cycle-diagram'
 export { default as Sinks } from './sinks-exploration'

--- a/story/story.mdx
+++ b/story/story.mdx
@@ -2,7 +2,7 @@ import { Box } from 'theme-ui'
 import { Figure } from '@carbonplan/components'
 import Story, { Authors, Cite, Sidenote } from '../components/layout'
 import { FigureCaption } from '../components'
-import { Map, FluxMaps, Sinks, OceanCycleDiagram } from './components'
+import { FCO2Maps, FluxMaps, Sinks, OceanCycleDiagram } from './components'
 import references from './references.json'
 
 # The ocean carbon sink
@@ -64,40 +64,17 @@ It’s impossible for scientists to go out to each location to collect observati
 Available measurements of fCO₂ are sparse around the ocean and are predominantly located in the northern hemisphere and along common shipping routes. Many data come from automated instruments installed on commercial ships. fCO₂ measurements are also being made on buoys and unmanned vehicles that are particularly good for accessing remote and inhospitable ocean regions.
 
 <Figure>
-  <Map
-    sourceUrl='https://carbonplan-data-viewer.s3.us-west-2.amazonaws.com/demo/leap-data-stories/SOCATv2019_tracks_gridded_monthly.zarr'
-    variable='fco2_ave_weighted'
-    clim={[280, 440]}
-    colormapName='warm'
-    label='Measured fCO₂'
-    units='μatm'
-    startYear={1970}
-    delay={100}
-/>
-
-  <FigureCaption number={3}>TK: SOCAT fCO₂ over time</FigureCaption>
+  <FCO2Maps />
+  <FigureCaption number={3}>
+    TK: Measured fCO₂ over time (left) and reconstructed fCO₂ over time (right)
+  </FigureCaption>
 </Figure>
 
 Despite decades of coordinated international efforts by ocean carbon scientists, fCO₂ observations are available for only a fraction of the vast global ocean. How do we understand the global ocean carbon sink where we do not have data? Machine Learning (ML) can be combined with full-coverage data from satellites and other sources to build full-coverage fCO₂ maps. From fCO₂, air-sea CO₂ fluxes can be calculated.
 
 <Figure>
-  <Map
-    sourceUrl='https://carbonplan-data-viewer.s3.us-west-2.amazonaws.com/demo/leap-data-stories/GCB-2023_dataprod_LDEO-HPD_1959-2022-flipped-lon.zarr'
-    variable='sfco2'
-    clim={[280, 440]}
-    label='Reconstructed fCO₂'
-    units='μatm'
-    colormapName='warm'
-    startYear={1959}
-  />
-  <FigureCaption number={4}>
-    global map of fCO₂ progressing in time
-  </FigureCaption>
-</Figure>
-
-<Figure>
   <FluxMaps />
-  <FigureCaption number={5}>
+  <FigureCaption number={4}>
     global map of mean carbon flux (mol/m2/yr).
   </FigureCaption>
 </Figure>


### PR DESCRIPTION
Considering combining the SOCAT figure and interpolated LDEO-HPD data into a single figure.

This includes a few changes
- Uses annually aggregated data (per suggestion at check-in meeting)
- Conveys the point about sparseness and does introduce a second figure to explain that full ocean can then be interpolated
  - Do you think we should play with the proportion of the maps here?
- For this and the flux figure below it, I could imagine replacing the draggable label with the "slide" pattern from https://github.com/carbonplan/leap-story-carbon-sink/pull/13