### PR TITLE
fig1 tweaks

### DIFF
--- a/pages/stories/ocean-sink/components/sinks.js
+++ b/pages/stories/ocean-sink/components/sinks.js
@@ -630,6 +630,7 @@ const SinksExploration = ({ debug = false }) => {
             x={10}
             y={Y_SCALE}
             align='right'
+            verticalAlign='bottom'
             sx={{
               fontSize: [2, 2, 2, 3],
               fontVariantNumeric: 'tabular-nums',

--- a/pages/stories/ocean-sink/components/sinks.js
+++ b/pages/stories/ocean-sink/components/sinks.js
@@ -50,6 +50,7 @@ const STEPS = [
   },
   {
     description: `Practices like cutting down trees and expanding cities used to be the biggest way people created carbon emissions. But in 1979, fossil fuel use surpassed these land-use change emissions as the primary driver of climate change.`,
+    yearProminent: true,
     subSteps: [
       {
         year: 1849,
@@ -125,6 +126,7 @@ const STEPS = [
   },
   {
     description: `Today, fossil fuels are far and away the largest source of carbon emissions. But the planet can help mitigate those emissions, draining carbon from the atmosphere through two “sinks” in the land and the ocean.`,
+    yearProminent: true,
     subSteps: [
       {
         year: 2022,
@@ -631,9 +633,9 @@ const SinksExploration = ({ debug = false }) => {
             verticalAlign='bottom'
             sx={{
               fontSize: [2, 2, 2, 3],
-              opacity: currentSubStep.year !== START_YEAR ? 1 : 0,
-              transition: 'opacity 0.5s ease-in-out',
               fontVariantNumeric: 'tabular-nums',
+              color: currentStep.yearProminent ? 'primary' : 'secondary',
+              transition: 'color 0.2s ease-in-out',
             }}
           >
             {START_YEAR} {' - '}

--- a/pages/stories/ocean-sink/components/sinks.js
+++ b/pages/stories/ocean-sink/components/sinks.js
@@ -343,7 +343,13 @@ const BudgetLabel = animated(
         {...props}
       >
         {category}
-        <Box sx={{ color: 'secondary', textTransform: 'none' }}>
+        <Box
+          sx={{
+            color: 'secondary',
+            textTransform: 'none',
+            fontVariantNumeric: 'tabular-nums',
+          }}
+        >
           <Box as={'span'} sx={{ color: 'primary' }}>
             {value}{' '}
           </Box>
@@ -627,6 +633,7 @@ const SinksExploration = ({ debug = false }) => {
               fontSize: [2, 2, 2, 3],
               opacity: currentSubStep.year !== START_YEAR ? 1 : 0,
               transition: 'opacity 0.5s ease-in-out',
+              fontVariantNumeric: 'tabular-nums',
             }}
           >
             {START_YEAR} {' - '}

--- a/pages/stories/ocean-sink/components/sinks.js
+++ b/pages/stories/ocean-sink/components/sinks.js
@@ -633,7 +633,7 @@ const SinksExploration = ({ debug = false }) => {
               fontSize: [2, 2, 2, 3],
               fontVariantNumeric: 'tabular-nums',
               color: currentSubStep.isYearAnimation ? 'primary' : 'secondary',
-              transition: 'color 0.2s ease-in-out',
+              transition: 'color 0.5s ease-in-out',
             }}
           >
             {START_YEAR} {' - '}

--- a/pages/stories/ocean-sink/components/sinks.js
+++ b/pages/stories/ocean-sink/components/sinks.js
@@ -600,7 +600,8 @@ const SinksExploration = ({ debug = false }) => {
           </Plot>
           <Label
             x={0}
-            y={2.3}
+            y={0.3} // slight discrepancy between bottom and top alignments
+            verticalAlign='bottom'
             sx={{
               opacity: axisOpacity,
               transition: 'opacity 0.5s ease-in-out',
@@ -614,6 +615,7 @@ const SinksExploration = ({ debug = false }) => {
           <Label
             x={0}
             y={-0.5}
+            verticalAlign='top'
             sx={{
               opacity: axisOpacity,
               transition: 'opacity 0.5s ease-in-out',
@@ -628,7 +630,6 @@ const SinksExploration = ({ debug = false }) => {
             x={10}
             y={Y_SCALE}
             align='right'
-            verticalAlign='bottom'
             sx={{
               fontSize: [2, 2, 2, 3],
               fontVariantNumeric: 'tabular-nums',

--- a/pages/stories/ocean-sink/components/sinks.js
+++ b/pages/stories/ocean-sink/components/sinks.js
@@ -50,7 +50,6 @@ const STEPS = [
   },
   {
     description: `Practices like cutting down trees and expanding cities used to be the biggest way people created carbon emissions. But in 1979, fossil fuel use surpassed these land-use change emissions as the primary driver of climate change.`,
-    yearProminent: true,
     subSteps: [
       {
         year: 1849,
@@ -126,7 +125,6 @@ const STEPS = [
   },
   {
     description: `Today, fossil fuels are far and away the largest source of carbon emissions. But the planet can help mitigate those emissions, draining carbon from the atmosphere through two “sinks” in the land and the ocean.`,
-    yearProminent: true,
     subSteps: [
       {
         year: 2022,
@@ -634,7 +632,7 @@ const SinksExploration = ({ debug = false }) => {
             sx={{
               fontSize: [2, 2, 2, 3],
               fontVariantNumeric: 'tabular-nums',
-              color: currentStep.yearProminent ? 'primary' : 'secondary',
+              color: currentSubStep.isYearAnimation ? 'primary' : 'secondary',
               transition: 'color 0.2s ease-in-out',
             }}
           >


### PR DESCRIPTION
added the magic `fontVariantNumeric: 'tabular-nums'` trick to both the years and the carbon values.

Tried a color change to emphasize the year during the two main year changing slides (2 & 3). Not totally sure if this is the right call.